### PR TITLE
Update go and fix build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.8 as build
+FROM golang:1.11.3-alpine3.8 as build
+
+RUN apk add --no-cache git
 
 WORKDIR /go/src/app
 COPY . .
@@ -6,7 +8,7 @@ COPY . .
 RUN go get -d -v ./
 RUN go install -v ./
 
-RUN go build -ldflags "-linkmode external -extldflags -static" -v .
+RUN CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -v .
 
 FROM busybox 
 COPY --from=build /go/src/app/app /redis_sentinel_k8s

--- a/redis_sentinel_k8s.go
+++ b/redis_sentinel_k8s.go
@@ -389,7 +389,7 @@ func main() {
 		// When master is found, Endpoint is set but host and port are not
 		NewMaster.MasterHost, NewMaster.MasterPort, err = net.SplitHostPort(NewMaster.EndPoint)
 		if err != nil {
-			log.Infof("Error getting host and port from host (%s): err :%v", NewMaster.Endpoint, err)
+			log.Infof("Error getting host and port from host (%s): err :%v", NewMaster.EndPoint, err)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
I just tried to use the updated version and ran into some issues, so fixed that but also thought I might as well update to the latest go. I pushed the resulting image to `ecosiadev/redis-sentinel-k8s:0.2.1`

cc @@blaw2422 